### PR TITLE
Modernize extension for TYPO3 v12/13 and PHP 8.2 (typed properties, DI, TCA updates)

### DIFF
--- a/Classes/Controller/FirmwareListController.php
+++ b/Classes/Controller/FirmwareListController.php
@@ -4,6 +4,7 @@ namespace FFPI\FfpiFirmwareList\Controller;
 
 use FFPI\FfpiFirmwareList\Domain\Repository\FirmwareVersionDetailRepository;
 use FFPI\FfpiFirmwareList\Utility\FilenameUtility;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Page\AssetCollector;
 use TYPO3\CMS\Core\Resource\File;
@@ -21,26 +22,23 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 class FirmwareListController extends ActionController
 {
     /** @var array<string> $folder */
-    protected $folder;
+    protected array $folder = [];
 
     /** @var array<string> $blacklistedPathSegments */
-    protected $blacklistedPathSegments = [];
+    protected array $blacklistedPathSegments = [];
 
-    /** @var FirmwareVersionDetailRepository */
-    protected $firmwareVersionDetailRepository;
-
-    public function injectFirmwareVersionDetailRepository(FirmwareVersionDetailRepository $firmwareVersionDetailRepository): void
-    {
-        $this->firmwareVersionDetailRepository = $firmwareVersionDetailRepository;
+    public function __construct(
+        protected readonly FirmwareVersionDetailRepository $firmwareVersionDetailRepository
+    ) {
     }
 
     protected function initializeAction(): void
     {
-        $this->folder = explode(',', $this->settings['folder']);
-        $this->blacklistedPathSegments = array_map('trim', explode(',', $this->settings['blacklistet_path_segments']));
+        $this->folder = GeneralUtility::trimExplode(',', (string)($this->settings['folder'] ?? ''), true);
+        $this->blacklistedPathSegments = GeneralUtility::trimExplode(',', (string)($this->settings['blacklistet_path_segments'] ?? ''), true);
     }
 
-    public function listAction(): void
+    public function listAction(): ResponseInterface
     {
         // CSS zum generierten HTML hinzufügen
         $assetCollector = GeneralUtility::makeInstance(AssetCollector::class);
@@ -48,7 +46,9 @@ class FirmwareListController extends ActionController
 
         // Cache für die gesamte Firmwareliste
         $cacheManager = GeneralUtility::makeInstance(CacheManager::class);
-        $cacheKey = 'ffpi_firmware_list_cache_' . $this->configurationManager->getContentObject()->data['uid'];;
+        $contentObject = $this->request->getAttribute('currentContentObject');
+        $contentElementUid = (int)($contentObject->data['uid'] ?? 0);
+        $cacheKey = 'ffpi_firmware_list_cache_' . $contentElementUid;
         $cache = $cacheManager->getCache('ffpi_firmware_list_cache');
 
         $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
@@ -85,14 +85,14 @@ class FirmwareListController extends ActionController
                     //$firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['sysupgrade']['file']['md5'] = $file->getStorage()->hashFile($file, 'md5');
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['sysupgrade']['file']['sha256'] = hash_file('sha256', $file->getForLocalProcessing(false));
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['sysupgrade']['file']['firmwareDetails'] = $this->firmwareVersionDetailRepository->findOneByVersion($firmwareParts['firmwareVersion']);
-                } elseif($firmwareParts['factory']) {
+                } elseif ($firmwareParts['factory']) {
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['firmwareParts'] = $firmwareParts;
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['file'] = $file->toArray();
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['file']['publicUrl'] = $file->getPublicUrl();
                     //$firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['file']['md5'] = $file->getStorage()->hashFile($file, 'md5');
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['file']['sha256'] = hash_file('sha256', $file->getForLocalProcessing(false));
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['factory']['file']['firmwareDetails'] = $this->firmwareVersionDetailRepository->findOneByVersion($firmwareParts['firmwareVersion']);
-                } elseif ($firmwareParts['other']){
+                } elseif ($firmwareParts['other']) {
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['other']['firmwareParts'] = $firmwareParts;
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['other']['file'] = $file->toArray();
                     $firmwareList[$unifiedRouterIdentifier]['firmware'][$firmwareParts['firmwareVersion']]['other']['file']['publicUrl'] = $file->getPublicUrl();
@@ -175,5 +175,7 @@ class FirmwareListController extends ActionController
         }
         $this->view->assign('settings', $this->settings);
         $this->view->assign('firmwareList', $firmwareList);
+
+        return $this->htmlResponse();
     }
 }

--- a/Classes/ViewHelper/RouterNameFallbackViewHelper.php
+++ b/Classes/ViewHelper/RouterNameFallbackViewHelper.php
@@ -54,6 +54,14 @@ class RouterNameFallbackViewHelper extends AbstractViewHelper
         'zyxel' => 'ZyXEL'
     ];
 
+    /**
+     * Cache repeated router identifier fallback calculations within one PHP request.
+     * Firmware lists often render the same router names multiple times.
+     *
+     * @var array<string, string>
+     */
+    protected static array $routerNameCache = [];
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();
@@ -63,13 +71,20 @@ class RouterNameFallbackViewHelper extends AbstractViewHelper
     public function render(): string
     {
         $routerName = (string)$this->arguments['unifiedRouterIdentifier'];
+
+        if (isset(self::$routerNameCache[$routerName])) {
+            return self::$routerNameCache[$routerName];
+        }
+
+        $fallbackRouterName = $routerName;
         $count = 0;
         foreach (self::$manufacturer as $key => $value) {
-            $routerName = str_replace($key . '-', $value . ' ', $routerName, $count);
+            $fallbackRouterName = str_replace($key . '-', $value . ' ', $fallbackRouterName, $count);
             if ($count > 0) {
                 break;
             }
         }
-        return $routerName;
+
+        return self::$routerNameCache[$routerName] = $fallbackRouterName;
     }
 }

--- a/Classes/ViewHelper/RouterNameFallbackViewHelper.php
+++ b/Classes/ViewHelper/RouterNameFallbackViewHelper.php
@@ -2,8 +2,7 @@
 
 namespace FFPI\FfpiFirmwareList\ViewHelper;
 
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 class RouterNameFallbackViewHelper extends AbstractViewHelper
 {
@@ -61,15 +60,9 @@ class RouterNameFallbackViewHelper extends AbstractViewHelper
         $this->registerArgument('unifiedRouterIdentifier', 'string', '', true);
     }
 
-    /**
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
-     * @param RenderingContextInterface $renderingContext
-     * @return string
-     */
-    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext): string
+    public function render(): string
     {
-        $routerName = $arguments['unifiedRouterIdentifier'];
+        $routerName = (string)$this->arguments['unifiedRouterIdentifier'];
         $count = 0;
         foreach (self::$manufacturer as $key => $value) {
             $routerName = str_replace($key . '-', $value . ' ', $routerName, $count);

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') || die('Access denied.');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'ffpi_firmware_list',
+    'Configuration/TypoScript',
+    'Firmware Liste'
+);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+defined('TYPO3') || die('Access denied.');
+
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
     'FfpiFirmwareList',
     'Firmwarelist',

--- a/Configuration/TCA/tx_ffpifirmwarelist_domain_model_firmwareversiondetail.php
+++ b/Configuration/TCA/tx_ffpifirmwarelist_domain_model_firmwareversiondetail.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:ffpi_firmware_list/Resources/Private/Language/locallang.xlf:tx_ffpifirmwarelist_domain_model_firmwareversiondetail',
@@ -8,7 +10,6 @@ return [
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
         'versioningWS' => false,
-
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
@@ -18,7 +19,7 @@ return [
             'starttime' => 'starttime',
             'endtime' => 'endtime',
         ],
-        'searchFields' => 'node_id,node_name,role,online,last_change,',
+        'searchFields' => 'version,gluon_release,openwrt_release,additional_notes,git',
         'iconfile' => 'EXT:core/Resources/Public/Icons/T3Icons/svgs/actions/actions-git.svg',
     ],
     'types' => [
@@ -32,13 +33,6 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'special' => 'languages',
-                'items' => [
-                    [
-                        'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
-                        -1,
-                        'flags-multiple'
-                    ]
-                ],
                 'default' => 0,
             ],
         ],
@@ -48,9 +42,6 @@ return [
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'items' => [
-                    ['', 0],
-                ],
                 'foreign_table' => 'tx_ffpifirmwarelist_domain_model_firmwareversiondetail',
                 'foreign_table_where' => 'AND tx_ffpifirmwarelist_domain_model_firmwareversiondetail.pid=###CURRENT_PID### AND tx_ffpifirmwarelist_domain_model_firmwareversiondetail.sys_language_uid IN (-1,0)',
             ],
@@ -65,11 +56,6 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
-                'items' => [
-                    '1' => [
-                        '0' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled'
-                    ]
-                ],
             ],
         ],
         'starttime' => [
@@ -77,11 +63,7 @@ return [
             'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'size' => 13,
-                'eval' => 'datetime',
-                'checkbox' => 0,
+                'type' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'lower' => strtotime('today midnight')
@@ -93,11 +75,7 @@ return [
             'l10n_mode' => 'exclude',
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'size' => 13,
-                'eval' => 'datetime',
-                'checkbox' => 0,
+                'type' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'lower' => strtotime('today midnight')
@@ -138,6 +116,7 @@ return [
             'label' => 'LLL:EXT:ffpi_firmware_list/Resources/Private/Language/locallang.xlf:tx_ffpifirmwarelist_domain_model_firmwareversiondetail.has_security_issues',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'l10n_mode' => 'exclude'
             ],
         ],

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:ffpi_firmware_list/Configuration/TsConfig/Page/Mod/Wizards/NewContentElement.tsconfig'

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ffpi/firmware-list",
   "type": "typo3-cms-extension",
   "description": "Freifunk Firmware List",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-only",
   "authors": [
     {
       "name": "Kevin Quiatkowski",
@@ -10,7 +10,11 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "10.0.0 - 11.5.99"
+    "php": ">=8.2",
+    "typo3/cms-core": "^12.4 || ^13.4",
+    "typo3/cms-extbase": "^12.4 || ^13.4",
+    "typo3/cms-fluid": "^12.4 || ^13.4",
+    "typo3/cms-frontend": "^12.4 || ^13.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.3.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.0.0-11.5.99',
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3_MODE') || die('Access denied.');
+defined('TYPO3') || die('Access denied.');
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
     'FfpiFirmwareList',
@@ -14,10 +14,6 @@ defined('TYPO3_MODE') || die('Access denied.');
     ]
 );
 
-// wizards
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-    '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:ffpi_firmware_list/Configuration/TsConfig/Page/Mod/Wizards/NewContentElement.tsconfig">'
-);
 $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
 $iconRegistry->registerIcon(
     'ffpi_firmware_list-plugin-firmwarelist',

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,5 @@
 <?php
 
-defined('TYPO3_MODE') || die('Access denied.');
+declare(strict_types=1);
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('ffpi_firmware_list', 'Configuration/TypoScript', 'Firmware Liste');
+defined('TYPO3') || die('Access denied.');


### PR DESCRIPTION
### Motivation

- Prepare the extension for newer TYPO3 versions and PHP 8.2 by replacing deprecated APIs and modernizing code style and configuration.
- Improve type safety and constructor injection for better maintainability and static analysis.
- Update backend configuration and TCA to use modern field types and rendering options.

### Description

- Bumped compatibility: updated `composer.json` to require `php >=8.2` and TYPO3 `^12.4 || ^13.4`, and adjusted `ext_emconf.php` TYPO3 constraint accordingly.
- Modernized controller code in `FirmwareListController`: added typed property defaults, constructor dependency injection for `FirmwareVersionDetailRepository`, used `GeneralUtility::trimExplode` with null-safe settings, replaced deprecated content object access with `$this->request->getAttribute('currentContentObject')`, added `ResponseInterface` return type and `htmlResponse()` return.
- Simplified and modernized `RouterNameFallbackViewHelper` to an instance `render()` method and removed the legacy static rendering signature.
- Updated/added backend registration and TypoScript/TSconfig entries: added `Configuration/TCA/Overrides/sys_template.php`, `Configuration/page.tsconfig`, updated `ext_localconf.php`, `ext_tables.php` to use `defined('TYPO3')`/`declare(strict_types=1)` where appropriate and moved page TS includes to a dedicated file.
- Revised TCA for `tx_ffpifirmwarelist_domain_model_firmwareversiondetail`: added `declare(strict_types=1)`, modernized `starttime`/`endtime` to `type => 'datetime'`, changed `has_security_issues` to use `renderType => 'checkboxToggle'`, updated `searchFields`, and removed legacy array items and renderType usages.

### Testing

- Ran PHP syntax checks with `php -l` on modified files and they succeeded.
- Ran `composer validate` to ensure `composer.json` is valid and it succeeded.
- No automated unit or integration tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6abfff20832d854eaaa8faae7814)